### PR TITLE
Instead of zope.app.file.interfaces.IFile use plone.namedfile.interfa…

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,8 +4,14 @@ Changelog
 1.2 (unreleased)
 ----------------
 
+Incompatibilities:
+
+- Instead of ``zope.app.file.interfaces.IFile`` use ``plone.namedfile.interfaces.IFile``.
+  [thet]
+
 - Fix missing Javascript call that breaks the widget
   [laulaz]
+
 - Add French and Dutch translations
   [laulaz]
 

--- a/plone/formwidget/multifile/utils.py
+++ b/plone/formwidget/multifile/utils.py
@@ -1,6 +1,6 @@
-from zope.publisher.interfaces import NotFound
 from Products.CMFCore.utils import getToolByName
-from zope.app.file.interfaces import IFile
+from plone.namedfile.interfaces import IFile
+from zope.publisher.interfaces import NotFound
 
 
 def get_icon_for(context, file_):


### PR DESCRIPTION
…ces.IFile.

plone.formwidget.multifile is a dependency on plone.app.standardtiles. since the latest plone.namedfile chnages ( https://github.com/plone/plone.namedfile/commit/ec2ea87d8867f87f848d63df53e27b0cd559a114 ) we lost the hard dependency on zope.app.file, which is not pulled in anymore. plone.formwidget.multifile was depending on it. here i simply change the dependency to use plone.namedfile.interfaces.IFile instead, which is what replaces zope.app.file.interfaces.IFile.